### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,13 +27,13 @@ jobs:
           # Add support for more platforms with QEMU (optional)
           # https://github.com/docker/setup-qemu-action
           name: Set up QEMU
-          uses: docker/setup-qemu-action@v3.1.0
+          uses: docker/setup-qemu-action@v3.2.0
         -
           # https://github.com/docker/setup-buildx-action/issues/57#issuecomment-1059657292
           # https://github.com/docker/buildx/issues/136#issuecomment-550205439
           # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
           name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3.4.0
+          uses: docker/setup-buildx-action@v3.5.0
           with:
             buildkitd-config: .github/buildkitd.toml
             driver-opts: |
@@ -42,20 +42,20 @@ jobs:
               env.no_proxy=${{ env.no_proxy }}
         -
           name: Login to DockerHub
-          uses: docker/login-action@v3.2.0
+          uses: docker/login-action@v3.3.0
           with:
             username: ${{ secrets.DOCKER_HUB_USERNAME }}
             password: ${{ secrets.DOCKER_HUB_PASSWORD }}
         -
           name: Login to GitHub Container Registry
-          uses: docker/login-action@v3.2.0
+          uses: docker/login-action@v3.3.0
           with:
             registry: ghcr.io
             username: ${{ github.repository_owner }}
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v6.4.1
+          uses: docker/build-push-action@v6.5.0
           with:
             context: .
             build-args: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.3.0](https://github.com/docker/login-action/releases/tag/v3.3.0)** on 2024-07-22T09:07:15Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.5.0](https://github.com/docker/build-push-action/releases/tag/v6.5.0)** on 2024-07-22T09:58:55Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.5.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.5.0)** on 2024-07-22T09:50:22Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.2.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.2.0)** on 2024-07-22T09:28:59Z
